### PR TITLE
Toggle start and suspend button by clicking each other

### DIFF
--- a/app/css/tinone.css
+++ b/app/css/tinone.css
@@ -5,3 +5,7 @@
 .end-true {
     visibility: hidden;
 }
+
+button.on {
+    display: none;
+}

--- a/app/index.html
+++ b/app/index.html
@@ -45,8 +45,8 @@
                 <span class="body">{{task.body}}</span>
               </td>
               <td>
-                <button class="start btn btn-primary start-{{task.done}}" ng-click="startClock($index)" ng-class="{on:task.clockStatus}">start</button>
-                <button class="suspend btn btn-warning suspend-{{task.done}}" ng-click="endClock($index)" ng-class="{on:!task.clockStatus}">suspend</button>
+                <button class="start btn btn-primary start-{{task.done}}" ng-click="startClock($index)" ng-class="{on:task.clockStatus == '計測中...'}">start</button>
+                <button class="suspend btn btn-warning suspend-{{task.done}}" ng-click="endClock($index)" ng-class="{on:task.clockStatus != '計測中...'}">suspend</button>
               </td>
               <td>
                 <span class="status text-info">{{task.clockStatus}}</span>

--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,6 @@
               <th class="col-md-1">done</th>
               <th class="col-md-6">body</th>
               <th class="col-md-1"></th>
-              <th class="col-md-1"></th>
               <th class="col-md-1">status</th>
               <th class="col-md-1">elapsed(min)</th>
               <th class="col-md-1"></th>
@@ -46,10 +45,8 @@
                 <span class="body">{{task.body}}</span>
               </td>
               <td>
-                <button class="start btn btn-primary start-{{task.done}}" ng-click="startClock($index)">start</button>
-              </td>
-              <td>
-                <button class="end btn btn-warning end-{{task.done}}" ng-click="endClock($index)">end</button>
+                <button class="start btn btn-primary start-{{task.done}}" ng-click="startClock($index)" ng-class="{on:task.clockStatus}">start</button>
+                <button class="suspend btn btn-warning suspend-{{task.done}}" ng-click="endClock($index)" ng-class="{on:!task.clockStatus}">suspend</button>
               </td>
               <td>
                 <span class="status text-info">{{task.clockStatus}}</span>


### PR DESCRIPTION
- ボタンをトグルするようにしました
- ボタンの名前が start, end よりも start, suspend の方がわかりやすそうなので変更しました
  - ただし、メソッド名は`endClock`の方が適切そうだったので変えていません

副次効果として、endを連続で押すとelapsedが増えるバグが起こらなくなりました〜。
